### PR TITLE
feat: Implement Like API, Implement like_count and liked return values in Book API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     - description → detail
     - index → table_of_contents
 - user에 name, salt, created_at 추가
+- book의 liked column 삭제 → 도서 조회 시 query로 like table에서 계산해서 반환
 
 ## 🔄️API Design
 [🔗API 명세 바로가기](https://do0ori.notion.site/Sprint2-Book-Store-Project-API-0fd148429624424f90a60d9d7de3d003?pvs=4)

--- a/controllers/likeController.js
+++ b/controllers/likeController.js
@@ -2,11 +2,39 @@ const conn = require('../mariadb');
 const { StatusCodes } = require('http-status-codes');
 
 const addToLikes = (req, res) => {
-    res.json("좋아요 추가");
+    const sql = "INSERT INTO likes (user_id, book_id) VALUES (?, ?)";
+    const values = [req.body.userId, req.params.bookId];
+    conn.query(
+        sql, values,
+        (err, results) => {
+            if (err) {
+                console.log(err);
+                return res.status(StatusCodes.BAD_REQUEST).end();
+            }
+
+            return res.status(StatusCodes.CREATED).json(results);
+        }
+    );
 };
 
 const removeFromLikes = (req, res) => {
-    res.json("좋아요 취소");
+    const sql = "DELETE FROM likes WHERE user_id = ? AND book_id = ?";
+    const values = [req.body.userId, req.params.bookId];
+    conn.query(
+        sql, values,
+        (err, results) => {
+            if (err) {
+                console.log(err);
+                return res.status(StatusCodes.BAD_REQUEST).end();
+            }
+
+            if (results.affectedRows == 0) {
+                return res.status(StatusCodes.BAD_REQUEST).end();
+            } else {
+                return res.status(StatusCodes.OK).json(results);
+            }
+        }
+    );
 };
 
 module.exports = {

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -55,6 +55,7 @@ const logIn = (req, res) => {
             if (loginUser && loginUser.password == hashedPassword) {
                 // JWT 발행
                 const token = jwt.sign({
+                    id: loginUser.id,
                     email: loginUser.email
                 }, process.env.PRIVATE_KEY, {
                     expiresIn: '5m',


### PR DESCRIPTION
# Changes Made
- 좋아요 API와 도서 API 모두 user의 id를 기반으로 구현해야 한다.
    - 이를 위해 JWT를 발행할 때 payload에 user의 id를 추가했다.
- SQL의 Subquery, `COUNT()`, `AS`, `EXISTS()` 문을 배우고 사용했다.
# Next Steps
- 실제로는 request header의 authorization field에 담긴 jwt를 검증하고 payload에 있는 id를 가져와야 하지만 지금은 일단 body에 userId를 담아 request를 보내는 것으로 했다. (추후 수정할 예정)