### PR TITLE
feat: Add error handling for JWT errors and introduce tokenVerification middleware for JWT verification

### DIFF
--- a/controllers/bookController.js
+++ b/controllers/bookController.js
@@ -9,16 +9,16 @@ const { StatusCodes } = require('http-status-codes');
  */
 const getBooks = async (req, res, next) => {
     try {
-        const { userId } = req.body;
+        const userId = req.decodedToken?.uid;
         const { categoryId, recent, limit, page } = req.query;
-    
+
         const conditions = {
             category: categoryId ? "category_id = ?" : null,
             recent: recent === "true" ? "published_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()" : null
         };
         const conditionClauses = Object.values(conditions).filter(Boolean);
         const whereClause = conditionClauses.length ? `WHERE ${conditionClauses.join(" AND ")}` : "";
-    
+
         let sql, values;
         if (limit && page) {
             const offset = limit * (page - 1);
@@ -37,7 +37,7 @@ const getBooks = async (req, res, next) => {
             values = categoryId ? [categoryId] : [];
         }
         const [rows] = await req.connection.query(sql, values);
-    
+
         if (rows.length) {
             res.status(StatusCodes.OK).json(rows);
         } else {
@@ -51,9 +51,9 @@ const getBooks = async (req, res, next) => {
 
 const getBookById = async (req, res, next) => {
     try {
-        const { userId } = req.body;
+        const userId = req.decodedToken?.uid;
         const { bookId } = req.params;
-    
+
         const sql = `
             SELECT
                 books.*,

--- a/controllers/likeController.js
+++ b/controllers/likeController.js
@@ -4,9 +4,9 @@ const { StatusCodes } = require('http-status-codes');
 const addToLikes = async (req, res, next) => {
     try {
         const sql = "INSERT INTO likes (user_id, book_id) VALUES (?, ?)";
-        const values = [req.body.userId, req.params.bookId];
+        const values = [req.decodedToken.uid, req.params.bookId];
         const [result] = await req.connection.query(sql, values);
-    
+
         res.status(StatusCodes.CREATED).json(result);
         next();
     } catch (error) {
@@ -17,9 +17,9 @@ const addToLikes = async (req, res, next) => {
 const removeFromLikes = async (req, res, next) => {
     try {
         const sql = "DELETE FROM likes WHERE user_id = ? AND book_id = ?";
-        const values = [req.body.userId, req.params.bookId];
+        const values = [req.decodedToken.uid, req.params.bookId];
         const [result] = await req.connection.query(sql, values);
-        
+
         if (result.affectedRows) {
             res.status(StatusCodes.OK).json(result);
         } else {

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -4,25 +4,25 @@ const { StatusCodes } = require('http-status-codes');
 // 나중에 transaction으로
 const submitOrder = async (req, res, next) => {
     try {
-        const { userId, items, delivery, totalQuantity, totalPrice, firstBookTitle } = req.body;
+        const { items, delivery, totalQuantity, totalPrice, firstBookTitle } = req.body;
 
         let sql = "INSERT INTO delivery (address, recipient, contact) VALUES (?, ?, ?)";
         let values = [delivery.address, delivery.recipient, delivery.contact];
         let [result] = await req.connection.query(sql, values);
-    
+
         const delivery_id = result.insertId;
-    
+
         sql = "INSERT INTO orders (user_id, delivery_id, book_title, total_quantity, total_price) VALUES (?, ?, ?, ?, ?)";
-        values = [userId, delivery_id, firstBookTitle, totalQuantity, totalPrice];
+        values = [req.decodedToken.uid, delivery_id, firstBookTitle, totalQuantity, totalPrice];
         [result] = await req.connection.query(sql, values);
-    
+
         const order_id = result.insertId;
-    
+
         sql = "INSERT INTO ordered_book (order_id, book_id, quantity) VALUES ?";
         values = [];
         items.forEach((item) => values.push([order_id, item.bookId, item.quantity]));
         [result] = await req.connection.query(sql, [values]);
-        
+
         sql = "DELETE FROM cart WHERE item_id IN (?)";
         values = [items.map(item => item.cartItemId)];
         [result] = await req.connection.query(sql, values);
@@ -40,8 +40,6 @@ const submitOrder = async (req, res, next) => {
 
 const getOrderList = async (req, res, next) => {
     try {
-        const { userId } = req.body;
-
         const sql = `
             SELECT
                 orders.id AS order_id,
@@ -57,7 +55,7 @@ const getOrderList = async (req, res, next) => {
             ON orders.delivery_id = delivery.id
             WHERE user_id = ?
         `;
-        const [rows] = await req.connection.query(sql, userId);
+        const [rows] = await req.connection.query(sql, req.decodedToken.uid);
 
         res.status(StatusCodes.OK).json(rows);
         next();

--- a/routes/books.js
+++ b/routes/books.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const router = express.Router();
+const verifyToken = require('../utils/tokenVerification');
 const {
     getBooks,
     getBookById
 } = require('../controllers/bookController');
 
+router.use(verifyToken(authMode = 'soft'));
 router.get('/', getBooks);
 router.get('/:bookId', getBookById);
 

--- a/routes/carts.js
+++ b/routes/carts.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const router = express.Router();
+const verifyToken = require('../utils/tokenVerification');
 const {
     addToCart,
     getCartItems,
     removeFromCart
 } = require('../controllers/cartController');
 
+router.use(verifyToken(authMode = 'hard'));
 router.post('/', addToCart);
 router.get('/', getCartItems);
 router.delete('/:itemId', removeFromCart);

--- a/routes/likes.js
+++ b/routes/likes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const router = express.Router();
+const verifyToken = require('../utils/tokenVerification');
 const {
     addToLikes,
     removeFromLikes
 } = require('../controllers/likeController');
 
+router.use(verifyToken(authMode = 'hard'));
 router.post('/:bookId', addToLikes);
 router.delete('/:bookId', removeFromLikes);
 

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const router = express.Router();
+const verifyToken = require('../utils/tokenVerification');
 const {
     submitOrder,
     getOrderList,
     getOrderDetails
 } = require('../controllers/orderController');
 
+router.use(verifyToken(authMode = 'hard'));
 router.post('/', submitOrder);
 router.get('/', getOrderList);
 router.get('/:orderId', getOrderDetails);

--- a/utils/errorHandler.js
+++ b/utils/errorHandler.js
@@ -1,4 +1,5 @@
 const { StatusCodes, getReasonPhrase } = require('http-status-codes');
+const { TokenExpiredError, JsonWebTokenError, NotBeforeError } = require('jsonwebtoken');
 
 class HttpError extends Error {
     constructor(statusCode, message) {
@@ -14,6 +15,8 @@ const errorHandler = (err, req, res, next) => {
     }
     if (err instanceof HttpError) {
         res.status(err.statusCode).json({ message: err.message });
+    } else if (err instanceof TokenExpiredError || err instanceof JsonWebTokenError || err instanceof NotBeforeError) {
+        res.status(StatusCodes.UNAUTHORIZED).send({ message: err.message });
     } else {
         console.error(`>> ${new Date().toLocaleString()}\n${err.stack}`);
         res.status(StatusCodes.BAD_REQUEST).send({ message: "Something went wrong!" });

--- a/utils/tokenVerification.js
+++ b/utils/tokenVerification.js
@@ -1,0 +1,41 @@
+const jwt = require('jsonwebtoken');
+const { StatusCodes } = require('http-status-codes');
+const { HttpError } = require('./errorHandler');
+require('dotenv').config();
+
+/**
+ * @param {string} [authMode='hard'] - Authentication mode. Use 'hard' to throw an error if the token is not provided, or 'soft' to allow unauthenticated users.
+ */
+const verifyToken = (authMode = 'hard') => {
+    const allowedModes = ['hard', 'soft'];
+
+    if (!allowedModes.includes(authMode)) {
+        throw new Error(`Invalid authentication mode '${authMode}'. Allowed modes are ${allowedModes.join(', ')}.`);
+    }
+
+    return (req, res, next) => {
+        try {
+            // Authorization: Bearer <token>
+            const AuthHeader = req.headers.authorization;
+
+            if (!AuthHeader) {
+                if (authMode === 'hard') {
+                    throw new HttpError(StatusCodes.UNAUTHORIZED, 'Token does not exist in Authorization header.');
+                } else if (authMode === 'soft') {
+                    next();
+                    return;
+                }
+            }
+
+            const token = AuthHeader.split(' ')[1];
+
+            const decoded = jwt.verify(token, process.env.PRIVATE_KEY, { ignoreExpiration: false });
+            req.decodedToken = decoded;
+            next();
+        } catch (error) {
+            next(error);
+        }
+    };
+};
+
+module.exports = verifyToken;


### PR DESCRIPTION
# Changes Made
- 기존에 Body에 담아보냈던 `userId`를 JWT 발행 시 payload에 담고, 이후 request header의 authorization field에 담아 보내도록 수정
- 강의에서는 `Authorization: <token>` 형식으로 보냈지만 [jwt.io](https://jwt.io/introduction)에서 header의 내용은 `Authorization: Bearer <token>`라고 나와 있기 때문에 이에 맞게 구현했다.
- tokenVerification middleware를 따로 만들어 코드에 전체적으로 도입했다.
    -  카테고리 API는 login을 하지 않아도 이용 가능
    - 도서 API는 login을 해도 되고 안 해도 이용 가능
    - 좋아요, 장바구니, 주문 API는 login 필수
- 도서 API에 `liked`가 있기 때문에 authorization header가 존재하지 않더라도 정상적으로 실행되어야 한다. 이 부분이 조금 까다로웠으나 tokenVerification middleware의 `verifyToken` 함수에 `authMode` option을 만들어 해결했다.