### PR TITLE
feat: Introduce access and refresh token to login API, Implement logout API, token refresh API and corresponding test codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 ## 🔄️API Design
 [🔗API 명세 바로가기](https://do0ori.notion.site/0787440aa79f4091902a0d4eadb5c009?v=1f96b9f02a704ea88a75567746da1499&pvs=4)
 
+- 🔑토큰 API
+    - access token 재발급 요청
 - 👤회원 API
     - 회원가입
     - 로그인

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - user에 name, salt, created_at 추가
 - book의 liked column 삭제 → 도서 조회 시 query로 like table에서 계산해서 반환
 - delivery Table을 만들어서 delivery 정보를 따로 저장
+- user_id와 refresh_token을 저장하는 token table 생성
 
 ## 🔄️API Design
 [🔗API 명세 바로가기](https://do0ori.notion.site/0787440aa79f4091902a0d4eadb5c009?v=1f96b9f02a704ea88a75567746da1499&pvs=4)
@@ -22,6 +23,7 @@
     - 로그인
     - 비밀번호 초기화 요청
     - 비밀번호 초기화
+    - 로그아웃
 - 📖도서 API
     - 도서 조회
     - 개별 도서 조회

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
 require('dotenv').config();
+const cookieParser = require('cookie-parser');
 const port = process.env.PORT || 3000;
 
 const userRouter = require('./src/routes/user.route');
@@ -11,14 +12,15 @@ const cartRouter = require('./src/routes/cart.route');
 const orderRouter = require('./src/routes/order.route');
 const { errorHandler } = require('./src/middlewares/errorHandler.middleware');
 
+app.use(cookieParser());
 app.use(express.json());
 
-app.use('/users', userRouter);
-app.use('/books', bookRouter);
-app.use('/category', categoryRouter);
-app.use('/likes', likeRouter);
-app.use('/cart', cartRouter);
-app.use('/orders', orderRouter);
+app.use('/api/users', userRouter);
+app.use('/api/books', bookRouter);
+app.use('/api/category', categoryRouter);
+app.use('/api/likes', likeRouter);
+app.use('/api/cart', cartRouter);
+app.use('/api/orders', orderRouter);
 
 app.use(errorHandler);
 

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ require('dotenv').config();
 const cookieParser = require('cookie-parser');
 const port = process.env.PORT || 3000;
 
+const tokenRouter = require('./src/routes/token.route');
 const userRouter = require('./src/routes/user.route');
 const bookRouter = require('./src/routes/book.route');
 const categoryRouter = require('./src/routes/category.route');
@@ -15,6 +16,7 @@ const { errorHandler } = require('./src/middlewares/errorHandler.middleware');
 app.use(cookieParser());
 app.use(express.json());
 
+app.use('/api/refresh', tokenRouter);
 app.use('/api/users', userRouter);
 app.use('/api/books', bookRouter);
 app.use('/api/category', categoryRouter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
@@ -369,6 +370,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test": "mocha test --exit"
   },
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",

--- a/src/controllers/token.controller.js
+++ b/src/controllers/token.controller.js
@@ -1,0 +1,37 @@
+const tokenService = require('../services/token.service');
+const jwt = require('jsonwebtoken');
+const { StatusCodes } = require('http-status-codes');
+const { HttpError } = require('../middlewares/errorHandler.middleware');
+const { issueToken } = require('../utils/authentication.util');
+const { asyncHandlerWrapper } = require('../middlewares/wrapper.middleware');
+
+const refreshToken = async (req, res) => {
+    const accessToken = req.headers.authorization.split(' ')[1];
+    const refreshToken = req.cookies.refreshToken;
+
+    try {
+        jwt.verify(accessToken, process.env.PRIVATE_KEY, { ignoreExpiration: false });
+        
+        throw new HttpError(StatusCodes.BAD_REQUEST, 'Access token is not expired.');
+    } catch (error) {
+        if (error.name === 'TokenExpiredError') {
+            const userId = jwt.verify(refreshToken, process.env.PRIVATE_KEY, { ignoreExpiration: true }).userId;
+
+            const isValid = await tokenService.isValidRefreshToken(req.conn, refreshToken, userId);
+
+            if (!isValid) {
+                throw new HttpError(StatusCodes.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해주세요.");
+            }
+
+            const newAccessToken = issueToken(userId, 'access');
+
+            res.status(StatusCodes.OK).json({ accessToken: newAccessToken });
+        } else {
+            throw error;
+        }
+    }
+};
+
+module.exports = {
+    refreshToken: asyncHandlerWrapper(refreshToken)
+};

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -15,10 +15,10 @@ const signUp = async (req, res) => {
 const logIn = async (req, res) => {
     const { email, password } = req.body;
 
-    const token = await userService.logIn(req.conn, email, password);
+    const { accessToken, refreshToken } = await userService.logIn(req.conn, email, password);
 
-    res.cookie("token", token, { httpOnly: true });
-    res.status(StatusCodes.OK).end();
+    res.cookie('refreshToken', refreshToken, { httpOnly: true, secure: true, sameSite: 'Strict' });
+    res.status(StatusCodes.OK).json({ accessToken });
 };
 
 const passwordResetRequest = async (req, res) => {
@@ -38,9 +38,19 @@ const resetPassword = async (req, res) => {
     res.status(StatusCodes.OK).json(data);
 };
 
+const logOut = async (req, res) => {
+    const userId = req.decodedToken.userId;
+
+    const data = await userService.logOut(req.conn, userId);
+
+    res.clearCookie('refreshToken');
+    res.status(StatusCodes.OK).json(data);
+};
+
 module.exports = {
     signUp: asyncHandlerWrapper(signUp),
     logIn: asyncHandlerWrapper(logIn),
     passwordResetRequest: asyncHandlerWrapper(passwordResetRequest),
-    resetPassword: asyncHandlerWrapper(resetPassword)
+    resetPassword: asyncHandlerWrapper(resetPassword),
+    logOut: asyncHandlerWrapper(logOut)
 };

--- a/src/middlewares/authorization.middleware.js
+++ b/src/middlewares/authorization.middleware.js
@@ -5,6 +5,7 @@ const { asyncHandlerWrapper } = require('./wrapper.middleware');
 require('dotenv').config();
 
 /**
+ * Middleware for verifying the validity of an access token in the Authorization header.
  * @param {string} [authMode='hard'] - Authentication mode. Use 'hard' to throw an error if the token is not provided, or 'soft' to allow unauthenticated users.
  */
 const verifyToken = (authMode = 'hard') => {
@@ -15,7 +16,7 @@ const verifyToken = (authMode = 'hard') => {
     }
 
     return asyncHandlerWrapper(async (req, res) => {
-        // Authorization: Bearer <token>
+        // Authorization: Bearer <access-token>
         const authHeader = req.headers.authorization;
 
         if (!authHeader) {
@@ -26,9 +27,9 @@ const verifyToken = (authMode = 'hard') => {
             }
         }
 
-        const token = authHeader.split(' ')[1];
+        const accessToken = authHeader.split(' ')[1];
 
-        const decoded = jwt.verify(token, process.env.PRIVATE_KEY, { ignoreExpiration: false });
+        const decoded = jwt.verify(accessToken, process.env.PRIVATE_KEY, { ignoreExpiration: false });
         req.decodedToken = decoded;
     });
 };

--- a/src/middlewares/errorHandler.middleware.js
+++ b/src/middlewares/errorHandler.middleware.js
@@ -12,9 +12,9 @@ class HttpError extends Error {
 const errorHandler = (err, req, res, next) => {
     console.error(`>> ${new Date().toLocaleString()}: ${err.stack}`);
 
-    if (err instanceof HttpError) {
+    if (err.name === "HttpError") {
         res.status(err.statusCode).json({ message: err.message });
-    } else if (err instanceof TokenExpiredError || err instanceof JsonWebTokenError || err instanceof NotBeforeError) {
+    } else if (err.name === "TokenExpiredError" || err.name === "JsonWebTokenError" || err.name === "NotBeforeError") {
         res.status(StatusCodes.UNAUTHORIZED).send({ message: err.message });
     } else if (err.code?.startsWith("ER_")) {
         res.status(StatusCodes.BAD_REQUEST).send({ message: "Send valid inputs." })

--- a/src/middlewares/validation.middleware.js
+++ b/src/middlewares/validation.middleware.js
@@ -57,8 +57,8 @@ const checkString = (location, field) => location(field).exists().isString();
  * Grouped Validation Chains
  */
 const tokenFieldValidation = [
-    header('Authorization').exists().withMessage('Authorization header is required'),
-    cookie('refreshToken').exists().withMessage('Refresh token is required'),
+    header('Authorization').exists().withMessage('Authorization header is required').isString(),
+    cookie('refreshToken').exists().withMessage('Refresh token is required').isString(),
     checkValidationResult
 ];
 

--- a/src/middlewares/validation.middleware.js
+++ b/src/middlewares/validation.middleware.js
@@ -1,4 +1,4 @@
-const { body, param, query, validationResult } = require('express-validator');
+const { body, param, query, header, cookie, validationResult } = require('express-validator');
 const { HttpError } = require('./errorHandler.middleware');
 const { StatusCodes } = require('http-status-codes');
 
@@ -7,10 +7,17 @@ const { StatusCodes } = require('http-status-codes');
  */
 const checkValidationResult = (req, res, next) => {
     const errors = validationResult(req);
+    const errorMessages = [];
 
-    if (!errors.isEmpty()) {
-        console.log(errors.array());
-        return next(new HttpError(StatusCodes.BAD_REQUEST, "Request input validation fails."));
+    errors.array().forEach(error => {
+        if (!errorMessages.includes(error.msg)) {
+            errorMessages.push(error.msg);
+        }
+    });
+    
+    if (errorMessages.length) {
+        const errorMessage = errorMessages.join(', ');
+        return next(new HttpError(StatusCodes.BAD_REQUEST, errorMessage));
     }
     
     next();
@@ -49,6 +56,12 @@ const checkString = (location, field) => location(field).exists().isString();
 /*
  * Grouped Validation Chains
  */
+const tokenFieldValidation = [
+    header('Authorization').exists().withMessage('Authorization header is required'),
+    cookie('refreshToken').exists().withMessage('Refresh token is required'),
+    checkValidationResult
+];
+
 const emailPasswordValidation = [
     checkEmail(body, 'email'),
     checkPassword(body, 'password', 8),
@@ -107,6 +120,8 @@ const orderIdValidation = [
  * Binding request handler to corresponding validator
  */
 const validator = {
+    refreshToken: tokenFieldValidation,
+
     signUp: emailPasswordValidation,
     logIn: emailPasswordValidation,
     passwordResetRequest: emailValidation,

--- a/src/routes/token.route.js
+++ b/src/routes/token.route.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const validator = require('../middlewares/validation.middleware');
+const tokenController = require('../controllers/token.controller');
+
+router.get('/', validator.refreshToken, tokenController.refreshToken);
+
+module.exports = router;

--- a/src/routes/user.route.js
+++ b/src/routes/user.route.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const verifyToken = require('../middlewares/authorization.middleware');
 const validator = require('../middlewares/validation.middleware');
 const userController = require('../controllers/user.controller');
 
@@ -7,5 +8,6 @@ router.post('/signup', validator.signUp, userController.signUp);
 router.post('/login', validator.logIn, userController.logIn);
 router.post('/reset-password', validator.passwordResetRequest, userController.passwordResetRequest);
 router.put('/reset-password', validator.resetPassword, userController.resetPassword);
+router.post('/logout', verifyToken(authMode = 'hard'), userController.logOut);
 
 module.exports = router;

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -63,19 +63,13 @@ const updateToken = async (conn, userId, refreshToken) => {
 };
 
 const removeToken = async (conn, userId) => {
-    const exists = await isTokenExist(conn, userId);
+    const sql = "DELETE FROM token WHERE user_id = ?";
+    const [result] = await conn.query(sql, userId);
 
-    if (exists) {
-        const sql = "DELETE FROM token WHERE user_id = ?";
-        const [result] = await conn.query(sql, userId);
-
-        if (result.affectedRows) {
-            return result;
-        } else {
-            throw new HttpError(StatusCodes.BAD_REQUEST);
-        }
+    if (result.affectedRows) {
+        return result;
     } else {
-        throw new HttpError(StatusCodes.CONFLICT, "이미 처리된 요청입니다.");
+        throw new HttpError(StatusCodes.BAD_REQUEST);
     }
 };
 

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -1,10 +1,49 @@
+const jwt = require('jsonwebtoken');
 const { StatusCodes } = require('http-status-codes');
 const { HttpError } = require('../middlewares/errorHandler.middleware');
 const { isTokenExist } = require('../utils/existanceCheck.util');
+require('dotenv').config();
+
+const getToken = async (conn, userId) => {
+    const exists = await isTokenExist(conn, userId);
+
+    if (exists) {
+        const sql = "SELECT refresh_token from token WHERE user_id = ?";
+        const [rows] = await conn.query(sql, userId);
+
+        return rows[0].refresh_token;
+    } else {
+        throw new HttpError(StatusCodes.NOT_FOUND, "해당 유저에게 발급된 refresh token이 없습니다.");
+    }
+};
+
+/**
+ * Checks if the provided refreshToken is valid for the given user.
+ *
+ * @param {string} refreshToken - The refresh token sent by the client.
+ * @param {string} userId - The user ID for whom the refresh token is being checked.
+ * @returns {boolean} - True if the refresh token is valid; otherwise, false.
+ */
+const isValidRefreshToken = async (conn, refreshToken, userId) => {
+    try {
+        const storedRefreshToken = await getToken(conn, userId);
+
+        if (refreshToken !== storedRefreshToken) {
+            return false;
+        }
+
+        jwt.verify(storedRefreshToken, process.env.PRIVATE_KEY, { ignoreExpiration: false });
+
+        return true;
+    } catch (error) {
+        console.log(error.stack);
+        return false;
+    }
+};
 
 const updateToken = async (conn, userId, refreshToken) => {
     const exists = await isTokenExist(conn, userId);
-
+    
     if (!exists) {
         const sql = "INSERT INTO token (user_id, refresh_token) VALUES (?, ?)";
         const values = [userId, refreshToken];
@@ -41,21 +80,8 @@ const removeToken = async (conn, userId) => {
     }
 };
 
-const getToken = async (conn, userId) => {
-    const exists = await isTokenExist(conn, userId);
-
-    if (exists) {
-        const sql = "SELECT refresh_token from token WHERE user_id = ?";
-        const [rows] = await conn.query(sql, userId);
-
-        return rows[0].refresh_token;
-    } else {
-        throw new HttpError(StatusCodes.NOT_FOUND, "해당 유저에게 발급된 refresh token이 없습니다.");
-    }
-};
-
 module.exports = {
+    isValidRefreshToken,
     updateToken,
-    removeToken,
-    getToken
+    removeToken
 };

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -36,7 +36,6 @@ const isValidRefreshToken = async (conn, refreshToken, userId) => {
 
         return true;
     } catch (error) {
-        console.log(error.stack);
         return false;
     }
 };

--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -1,0 +1,61 @@
+const { StatusCodes } = require('http-status-codes');
+const { HttpError } = require('../middlewares/errorHandler.middleware');
+const { isTokenExist } = require('../utils/existanceCheck.util');
+
+const updateToken = async (conn, userId, refreshToken) => {
+    const exists = await isTokenExist(conn, userId);
+
+    if (!exists) {
+        const sql = "INSERT INTO token (user_id, refresh_token) VALUES (?, ?)";
+        const values = [userId, refreshToken];
+        const [result] = await conn.query(sql, values);
+
+        return result;
+    } else {
+        const sql = "UPDATE token SET refresh_token = ? WHERE user_id = ?";
+        const values = [refreshToken, userId];
+        const [result] = await conn.query(sql, values);
+
+        if (result.affectedRows) {
+            return result;
+        } else {
+            throw new HttpError(StatusCodes.BAD_REQUEST);
+        }
+    }
+};
+
+const removeToken = async (conn, userId) => {
+    const exists = await isTokenExist(conn, userId);
+
+    if (exists) {
+        const sql = "DELETE FROM token WHERE user_id = ?";
+        const [result] = await conn.query(sql, userId);
+
+        if (result.affectedRows) {
+            return result;
+        } else {
+            throw new HttpError(StatusCodes.BAD_REQUEST);
+        }
+    } else {
+        throw new HttpError(StatusCodes.CONFLICT, "이미 처리된 요청입니다.");
+    }
+};
+
+const getToken = async (conn, userId) => {
+    const exists = await isTokenExist(conn, userId);
+
+    if (exists) {
+        const sql = "SELECT refresh_token from token WHERE user_id = ?";
+        const [rows] = await conn.query(sql, userId);
+
+        return rows[0].refresh_token;
+    } else {
+        throw new HttpError(StatusCodes.NOT_FOUND, "해당 유저에게 발급된 refresh token이 없습니다.");
+    }
+};
+
+module.exports = {
+    updateToken,
+    removeToken,
+    getToken
+};

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -26,8 +26,8 @@ const logIn = async (conn, email, password) => {
     const { hashedPassword } = encryptPassword(password, loginUser?.salt);
 
     if (loginUser && loginUser.password === hashedPassword) {
-        const accessToken = issueToken(loginUser, 'access');
-        const refreshToken = issueToken(loginUser, 'refresh');
+        const accessToken = issueToken(loginUser.id, 'access');
+        const refreshToken = issueToken(loginUser.id, 'refresh');
 
         await tokenService.updateToken(conn, loginUser.id, refreshToken);
 

--- a/src/utils/authentication.util.js
+++ b/src/utils/authentication.util.js
@@ -22,13 +22,31 @@ const encryptPassword = (rawPassword, salt = null) => {
     return { salt, hashedPassword };
 };
 
-const issueToken = (loginUser) => {
+/**
+ * Generates a JSON Web Token (JWT) for the specified user and token type.
+ *
+ * @param {Object} user - The user object containing user information.
+ * @param {string} [tokenType='access'] - The type of token to be generated ('access' or 'refresh').
+ * @returns {string} - The generated JWT.
+ *
+ * @throws {Error} Will throw an error if there is an issue with JWT signing.
+ *
+ * @example
+ * const accessToken = issueToken(user, 'access');
+ * const refreshToken = issueToken(user, 'refresh');
+ */
+const issueToken = (user, tokenType = 'access') => {
+    const tokenLifeTime = {
+        access: process.env.ACCESS_TOKEN_LIFETIME,
+        refresh: process.env.REFRESH_TOKEN_LIFETIME
+    };
+
     const payload = {
-        userId: loginUser.id
+        userId: user.id
     };
 
     const options = {
-        expiresIn: process.env.TOKEN_LIFETIME,
+        expiresIn: tokenLifeTime[tokenType],
         issuer: process.env.ISSUER
     };
 

--- a/src/utils/authentication.util.js
+++ b/src/utils/authentication.util.js
@@ -25,24 +25,24 @@ const encryptPassword = (rawPassword, salt = null) => {
 /**
  * Generates a JSON Web Token (JWT) for the specified user and token type.
  *
- * @param {Object} user - The user object containing user information.
+ * @param {number} userId - The user ID.
  * @param {string} [tokenType='access'] - The type of token to be generated ('access' or 'refresh').
  * @returns {string} - The generated JWT.
  *
  * @throws {Error} Will throw an error if there is an issue with JWT signing.
  *
  * @example
- * const accessToken = issueToken(user, 'access');
- * const refreshToken = issueToken(user, 'refresh');
+ * const accessToken = issueToken(userId, 'access');
+ * const refreshToken = issueToken(userId, 'refresh');
  */
-const issueToken = (user, tokenType = 'access') => {
+const issueToken = (userId, tokenType = 'access') => {
     const tokenLifeTime = {
         access: process.env.ACCESS_TOKEN_LIFETIME,
         refresh: process.env.REFRESH_TOKEN_LIFETIME
     };
 
     const payload = {
-        userId: user.id
+        userId
     };
 
     const options = {

--- a/src/utils/existanceCheck.util.js
+++ b/src/utils/existanceCheck.util.js
@@ -7,7 +7,7 @@
 const isUserExist = async (conn, email) => {
     const sql = "SELECT EXISTS (SELECT 1 FROM users WHERE email = ?) AS exist";
     const [result] = await conn.query(sql, email);
-    
+
     return result[0].exist === 1;
 };
 
@@ -26,7 +26,21 @@ const isLikeExist = async (conn, userId, bookId) => {
     return result[0].exist === 1;
 };
 
+/**
+ * Checks whether a token record exists for a given user.
+ * @param {Object} conn - The database connection object.
+ * @param {number} userId - The ID of the user.
+ * @returns {Promise<boolean>} A promise that resolves to a boolean indicating whether the token record exists (true) or not (false).
+ */
+const isTokenExist = async (conn, userId) => {
+    const sql = "SELECT EXISTS (SELECT 1 FROM token WHERE user_id = ?) AS exist";
+    const [result] = await conn.query(sql, userId);
+
+    return result[0].exist === 1;
+};
+
 module.exports = {
     isUserExist,
-    isLikeExist
+    isLikeExist,
+    isTokenExist
 };

--- a/test/README.md
+++ b/test/README.md
@@ -14,81 +14,94 @@ npm test
 
 ## 📊Test result
 ```bash
-도서 조회
+  도서 조회
     정상 요청
-      ✔ GET /books?limit&page 요청 시 도서 목록 반환
+      ✔ GET /api/books?categoryId&recent&limit&page 요청 시 도서 목록 반환
     limit 누락
-      ✔ GET /books?page 요청 시 잘못된 요청임을 알림
+      ✔ GET /api/books?categoryId&recent&page 요청 시 잘못된 요청임을 알림
     page 누락
-      ✔ GET /books?limit 요청 시 잘못된 요청임을 알림
+      ✔ GET /api/books?categoryId&recent&limit 요청 시 잘못된 요청임을 알림
     없는 페이지
-      ✔ GET /books?limit&page 요청 시 존재하지 않는 페이지임을 알림
+      ✔ GET /api/books?categoryId&recent&limit&page 요청 시 존재하지 않는 페이지임을 알림
 
-도서 개별 조회
+  도서 개별 조회
     정상 요청
-      ✔ GET /books/{bookId} 요청 시 해당 도서 정보 반환
+      ✔ GET /api/books/{bookId} 요청 시 해당 도서 정보 반환
     없는 도서 요청
-      ✔ GET /books/{bookId} 요청 시 존재하지 않는 도서임을 알림
+      ✔ GET /api/books/{bookId} 요청 시 존재하지 않는 도서임을 알림
 
-장바구니 담기
-    ✔ POST /cart 요청 시 장바구니 record 추가 (47ms)
-    ✔ POST /cart 요청 시 같은 item도 따로 장바구니 record 추가 (93ms)
+  장바구니 담기
+    ✔ POST /api/cart 요청 시 장바구니 record 추가
+    ✔ POST /api/cart 요청 시 같은 item도 따로 장바구니 record 추가
 
-(선택한) 장바구니 목록 조회
-    ✔ GET /cart 요청 시 장바구니 목록 반환
+  (선택한) 장바구니 목록 조회
+    ✔ GET /api/cart 요청 시 장바구니 목록 반환
 
-장바구니 삭제
+  장바구니 삭제
     정상 요청
-      ✔ DELETE /cart/{itemId} 요청 시 해당 아이템 record 삭제
+      ✔ DELETE /api/cart/{itemId} 요청 시 해당 아이템 record 삭제
     중복된 요청
-      ✔ DELETE /cart/{itemId} 요청 시 이미 처리된 요청임을 알림
+      ✔ DELETE /api/cart/{itemId} 요청 시 이미 처리된 요청임을 알림
 
-결제 주문하기
-    ✔ POST /orders 요청 시 주문 transaction 실행
+  결제 주문하기
+    ✔ POST /api/orders 요청 시 주문 transaction 실행
 
-주문 목록(내역) 조회
-    ✔ GET /orders 요청 시 장바구니 목록 반환
+  주문 목록(내역) 조회
+    ✔ GET /api/orders 요청 시 장바구니 목록 반환
 
-주문 상세 상품 조회
-    ✔ GET /orders/{orderId} 요청 시 이미 처리된 요청임을 알림
+  주문 상세 상품 조회
+    ✔ GET /api/orders/{orderId} 요청 시 이미 처리된 요청임을 알림
 
-카테고리 전체 조회
-    ✔ GET /category 요청 시 카테고리 전체 목록 반환
+  카테고리 전체 조회
+    ✔ GET /api/category 요청 시 카테고리 전체 목록 반환
 
-좋아요 추가
+  좋아요 추가
     정상 요청
-      ✔ POST /likes/{bookId} 요청 시 좋아요 record 추가
+      ✔ POST /api/likes/{bookId} 요청 시 좋아요 record 추가
     중복된 요청
-      ✔ POST /likes/{bookId} 요청 시 이미 처리된 요청임을 알림
+      ✔ POST /api/likes/{bookId} 요청 시 이미 처리된 요청임을 알림
 
-좋아요 취소
+  좋아요 취소
     정상 요청
-      ✔ DELETE /likes/{bookId} 요청 시 좋아요 record 삭제
-      ✔ DELETE /likes/{bookId} 요청 시 이미 처리된 요청임을 알림
+      ✔ DELETE /api/likes/{bookId} 요청 시 좋아요 record 삭제
+    중복된 요청
+      ✔ DELETE /api/likes/{bookId} 요청 시 이미 처리된 요청임을 알림
 
-회원가입
+  토큰 재발급
+    정상 요청
+      ✔ GET /api/refresh 요청 시 accessToken 반환
+    만료되지 않은 access token 사용
+      ✔ GET /api/refresh 요청 시 만료되지 않았음을 알림
+
+  회원가입
     짧은 비밀번호
-      ✔ POST /users/signup 요청 시 잘못된 요청임을 알림
+      ✔ POST /api/users/signup 요청 시 잘못된 요청임을 알림
     정상 요청
-      ✔ POST /users/signup 요청 시 회원 정보 추가
+      ✔ POST /api/users/signup 요청 시 회원 정보 추가
     가입된 계정
-      ✔ POST /users/signup 요청 시 이미 가입된 계정임을 알림
+      ✔ POST /api/users/signup 요청 시 이미 가입된 계정임을 알림
 
-로그인
-    ✔ POST /users/login 요청 시 JWT 반환
+  로그인
+    ✔ POST /api/users/login 요청 시 JWT 반환
 
-비밀번호 초기화(재설정) 요청
+  비밀번호 초기화(재설정) 요청
     정상 요청
-      ✔ POST /users/reset-password 요청 시 email 반환
+      ✔ POST /api/users/reset-password 요청 시 email 반환
     가입된 적 없는 email
-      ✔ POST /users/reset-password 요청 시 unauthorized 반환
+      ✔ POST /api/users/reset-password 요청 시 unauthorized 반환
 
-비밀번호 초기화(재설정)
+  비밀번호 초기화(재설정)
     짧은 비밀번호
-      ✔ PUT /users/reset-password 요청 시 잘못된 요청임을 알림
+      ✔ PUT /api/users/reset-password 요청 시 잘못된 요청임을 알림
     정상 요청
-      ✔ PUT /users/reset-password 요청 시 email 반환
+      ✔ PUT /api/users/reset-password 요청 시 email 반환
+
+  로그아웃
+    정상 요청
+      ✔ POST /api/users/logout 요청 시 refreshToken cookie 삭제
+    중복된 요청
+      ✔ POST /api/users/logout 요청 시 이미 처리된 요청임을 알림
 
 
-27 passing (374ms)
+  31 passing (337ms)
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -82,7 +82,7 @@ npm test
       ✔ POST /api/users/signup 요청 시 이미 가입된 계정임을 알림
 
   로그인
-    ✔ POST /api/users/login 요청 시 JWT 반환
+    ✔ POST /api/users/login 요청 시 access & refresh token 반환
 
   비밀번호 초기화(재설정) 요청
     정상 요청
@@ -100,8 +100,8 @@ npm test
     정상 요청
       ✔ POST /api/users/logout 요청 시 refreshToken cookie 삭제
     중복된 요청
-      ✔ POST /api/users/logout 요청 시 이미 처리된 요청임을 알림
+      ✔ POST /api/users/logout 요청 시 이미 refresh token이 삭제되었으므로 재로그인 안내
 
 
-  31 passing (337ms)
+  31 passing (284ms)
 ```

--- a/test/book.test.js
+++ b/test/book.test.js
@@ -26,14 +26,7 @@ describe('도서 조회', () => {
         it('GET /api/books?categoryId&recent&page 요청 시 잘못된 요청임을 알림', (done) => {
             request(app)
                 .get('/api/books?page=1')
-                .expect(StatusCodes.BAD_REQUEST)
-                .end((err, res) => {
-                    if (err) return done(err);
-
-                    assert.strictEqual(res.body.message, "Request input validation fails.");
-
-                    return done();
-                });
+                .expect(StatusCodes.BAD_REQUEST, done);
         });
     });
 
@@ -41,14 +34,7 @@ describe('도서 조회', () => {
         it('GET /api/books?categoryId&recent&limit 요청 시 잘못된 요청임을 알림', (done) => {
             request(app)
                 .get('/api/books?limit=2')
-                .expect(StatusCodes.BAD_REQUEST)
-                .end((err, res) => {
-                    if (err) return done(err);
-
-                    assert.strictEqual(res.body.message, "Request input validation fails.");
-
-                    return done();
-                });
+                .expect(StatusCodes.BAD_REQUEST, done);
         });
     });
 

--- a/test/book.test.js
+++ b/test/book.test.js
@@ -5,9 +5,9 @@ const { StatusCodes } = require('http-status-codes');
 
 describe('도서 조회', () => {
     describe('정상 요청', () => {
-        it('GET /books?categoryId&recent&limit&page 요청 시 도서 목록 반환', (done) => {
+        it('GET /api/books?categoryId&recent&limit&page 요청 시 도서 목록 반환', (done) => {
             request(app)
-                .get('/books?limit=2&page=1')
+                .get('/api/books?limit=2&page=1')
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -23,9 +23,9 @@ describe('도서 조회', () => {
     });
 
     describe('limit 누락', () => {
-        it('GET /books?categoryId&recent&page 요청 시 잘못된 요청임을 알림', (done) => {
+        it('GET /api/books?categoryId&recent&page 요청 시 잘못된 요청임을 알림', (done) => {
             request(app)
-                .get('/books?page=1')
+                .get('/api/books?page=1')
                 .expect(StatusCodes.BAD_REQUEST)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -38,9 +38,9 @@ describe('도서 조회', () => {
     });
 
     describe('page 누락', () => {
-        it('GET /books?categoryId&recent&limit 요청 시 잘못된 요청임을 알림', (done) => {
+        it('GET /api/books?categoryId&recent&limit 요청 시 잘못된 요청임을 알림', (done) => {
             request(app)
-                .get('/books?limit=2')
+                .get('/api/books?limit=2')
                 .expect(StatusCodes.BAD_REQUEST)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -53,9 +53,9 @@ describe('도서 조회', () => {
     });
 
     describe('없는 페이지', () => {
-        it('GET /books?categoryId&recent&limit&page 요청 시 존재하지 않는 페이지임을 알림', (done) => {
+        it('GET /api/books?categoryId&recent&limit&page 요청 시 존재하지 않는 페이지임을 알림', (done) => {
             request(app)
-                .get('/books?limit=2&page=10')
+                .get('/api/books?limit=2&page=10')
                 .expect(StatusCodes.NOT_FOUND)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -70,9 +70,9 @@ describe('도서 조회', () => {
 
 describe('도서 개별 조회', () => {
     describe('정상 요청', () => {
-        it('GET /books/{bookId} 요청 시 해당 도서 정보 반환', (done) => {
+        it('GET /api/books/{bookId} 요청 시 해당 도서 정보 반환', (done) => {
             request(app)
-                .get('/books/1')
+                .get('/api/books/1')
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -85,9 +85,9 @@ describe('도서 개별 조회', () => {
     });
 
     describe('없는 도서 요청', () => {
-        it('GET /books/{bookId} 요청 시 존재하지 않는 도서임을 알림', (done) => {
+        it('GET /api/books/{bookId} 요청 시 존재하지 않는 도서임을 알림', (done) => {
             request(app)
-                .get('/books/10')
+                .get('/api/books/10')
                 .expect(StatusCodes.NOT_FOUND)
                 .end((err, res) => {
                     if (err) return done(err);

--- a/test/cart-order.test.js
+++ b/test/cart-order.test.js
@@ -15,6 +15,7 @@ describe('장바구니 담기', () => {
         request(app)
             .post('/api/cart')
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .send({ bookId: 4, quantity: 1 })
             .expect(StatusCodes.CREATED)
             .end((err, res) => {
@@ -31,6 +32,7 @@ describe('장바구니 담기', () => {
         request(app)
             .post('/api/cart')
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .send({ bookId: 4, quantity: 1 })
             .expect(StatusCodes.CREATED)
             .end((err, res) => {
@@ -49,6 +51,7 @@ describe('(선택한) 장바구니 목록 조회', () => {
         request(app)
             .get('/api/cart')
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .send({ selected: [insertId] })
             .expect(StatusCodes.OK)
             .end((err, res) => {
@@ -67,6 +70,7 @@ describe('장바구니 삭제', () => {
             request(app)
                 .delete(`/api/cart/${insertId}`)
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -83,6 +87,7 @@ describe('장바구니 삭제', () => {
             request(app)
                 .delete(`/api/cart/${insertId}`)
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -111,6 +116,7 @@ describe('결제 주문하기', () => {
         request(app)
             .post('/api/orders')
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .send({
                 items: [{ cartItemId: itemId, bookId: 4, quantity: 1 }],
                 delivery: fakeUserDelivery,
@@ -127,6 +133,7 @@ describe('주문 목록(내역) 조회', () => {
         request(app)
             .get('/api/orders')
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .expect(StatusCodes.OK)
             .end((err, res) => {
                 if (err) return done(err);
@@ -145,6 +152,7 @@ describe('주문 상세 상품 조회', () => {
         request(app)
             .get(`/api/orders/${orderId}`)
             .set("Authorization", `Bearer ${token}`)
+            .set("Cookie", `refreshToken=${token}`)
             .expect(StatusCodes.OK)
             .end((err, res) => {
                 if (err) return done(err);

--- a/test/cart-order.test.js
+++ b/test/cart-order.test.js
@@ -11,9 +11,9 @@ let insertId;
 
 // cart test
 describe('장바구니 담기', () => {
-    it('POST /cart 요청 시 장바구니 record 추가', (done) => {
+    it('POST /api/cart 요청 시 장바구니 record 추가', (done) => {
         request(app)
-            .post('/cart')
+            .post('/api/cart')
             .set("Authorization", `Bearer ${token}`)
             .send({ bookId: 4, quantity: 1 })
             .expect(StatusCodes.CREATED)
@@ -27,9 +27,9 @@ describe('장바구니 담기', () => {
             });
     });
 
-    it('POST /cart 요청 시 같은 item도 따로 장바구니 record 추가', (done) => {
+    it('POST /api/cart 요청 시 같은 item도 따로 장바구니 record 추가', (done) => {
         request(app)
-            .post('/cart')
+            .post('/api/cart')
             .set("Authorization", `Bearer ${token}`)
             .send({ bookId: 4, quantity: 1 })
             .expect(StatusCodes.CREATED)
@@ -45,9 +45,9 @@ describe('장바구니 담기', () => {
 });
 
 describe('(선택한) 장바구니 목록 조회', () => {
-    it('GET /cart 요청 시 장바구니 목록 반환', (done) => {
+    it('GET /api/cart 요청 시 장바구니 목록 반환', (done) => {
         request(app)
-            .get('/cart')
+            .get('/api/cart')
             .set("Authorization", `Bearer ${token}`)
             .send({ selected: [insertId] })
             .expect(StatusCodes.OK)
@@ -63,9 +63,9 @@ describe('(선택한) 장바구니 목록 조회', () => {
 
 describe('장바구니 삭제', () => {
     describe('정상 요청', () => {
-        it('DELETE /cart/{itemId} 요청 시 해당 아이템 record 삭제', (done) => {
+        it('DELETE /api/cart/{itemId} 요청 시 해당 아이템 record 삭제', (done) => {
             request(app)
-                .delete(`/cart/${insertId}`)
+                .delete(`/api/cart/${insertId}`)
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
@@ -79,9 +79,9 @@ describe('장바구니 삭제', () => {
     });
 
     describe('중복된 요청', () => {
-        it('DELETE /cart/{itemId} 요청 시 이미 처리된 요청임을 알림', (done) => {
+        it('DELETE /api/cart/{itemId} 요청 시 이미 처리된 요청임을 알림', (done) => {
             request(app)
-                .delete(`/cart/${insertId}`)
+                .delete(`/api/cart/${insertId}`)
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {
@@ -107,9 +107,9 @@ let orderId;
 
 // order test
 describe('결제 주문하기', () => {
-    it('POST /orders 요청 시 주문 transaction 실행', (done) => {
+    it('POST /api/orders 요청 시 주문 transaction 실행', (done) => {
         request(app)
-            .post('/orders')
+            .post('/api/orders')
             .set("Authorization", `Bearer ${token}`)
             .send({
                 items: [{ cartItemId: itemId, bookId: 4, quantity: 1 }],
@@ -123,9 +123,9 @@ describe('결제 주문하기', () => {
 });
 
 describe('주문 목록(내역) 조회', () => {
-    it('GET /orders 요청 시 장바구니 목록 반환', (done) => {
+    it('GET /api/orders 요청 시 장바구니 목록 반환', (done) => {
         request(app)
-            .get('/orders')
+            .get('/api/orders')
             .set("Authorization", `Bearer ${token}`)
             .expect(StatusCodes.OK)
             .end((err, res) => {
@@ -141,9 +141,9 @@ describe('주문 목록(내역) 조회', () => {
 });
 
 describe('주문 상세 상품 조회', () => {
-    it('GET /orders/{orderId} 요청 시 이미 처리된 요청임을 알림', (done) => {
+    it('GET /api/orders/{orderId} 요청 시 이미 처리된 요청임을 알림', (done) => {
         request(app)
-            .get(`/orders/${orderId}`)
+            .get(`/api/orders/${orderId}`)
             .set("Authorization", `Bearer ${token}`)
             .expect(StatusCodes.OK)
             .end((err, res) => {

--- a/test/category.test.js
+++ b/test/category.test.js
@@ -4,9 +4,9 @@ const app = require('../app');
 const { StatusCodes } = require('http-status-codes');
 
 describe('카테고리 전체 조회', () => {
-    it('GET /category 요청 시 카테고리 전체 목록 반환', (done) => {
+    it('GET /api/category 요청 시 카테고리 전체 목록 반환', (done) => {
         request(app)
-            .get('/category')
+            .get('/api/category')
             .expect(StatusCodes.OK)
             .end((err, res) => {
                 if (err) return done(err);

--- a/test/like.test.js
+++ b/test/like.test.js
@@ -11,6 +11,7 @@ describe('좋아요 추가', () => {
             request(app)
                 .post('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.CREATED)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -27,6 +28,7 @@ describe('좋아요 추가', () => {
             request(app)
                 .post('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -45,6 +47,7 @@ describe('좋아요 취소', () => {
             request(app)
                 .delete('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
                     if (err) return done(err);
@@ -61,6 +64,7 @@ describe('좋아요 취소', () => {
             request(app)
                 .delete('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
+                .set("Cookie", `refreshToken=${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {
                     if (err) return done(err);

--- a/test/like.test.js
+++ b/test/like.test.js
@@ -7,9 +7,9 @@ const token = process.env.TEST_TOKEN
 
 describe('좋아요 추가', () => {
     describe('정상 요청', () => {
-        it('POST /likes/{bookId} 요청 시 좋아요 record 추가', (done) => {
+        it('POST /api/likes/{bookId} 요청 시 좋아요 record 추가', (done) => {
             request(app)
-                .post('/likes/1')
+                .post('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.CREATED)
                 .end((err, res) => {
@@ -23,9 +23,9 @@ describe('좋아요 추가', () => {
     });
 
     describe('중복된 요청', () => {
-        it('POST /likes/{bookId} 요청 시 이미 처리된 요청임을 알림', (done) => {
+        it('POST /api/likes/{bookId} 요청 시 이미 처리된 요청임을 알림', (done) => {
             request(app)
-                .post('/likes/1')
+                .post('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {
@@ -41,9 +41,9 @@ describe('좋아요 추가', () => {
 
 describe('좋아요 취소', () => {
     describe('정상 요청', () => {
-        it('DELETE /likes/{bookId} 요청 시 좋아요 record 삭제', (done) => {
+        it('DELETE /api/likes/{bookId} 요청 시 좋아요 record 삭제', (done) => {
             request(app)
-                .delete('/likes/1')
+                .delete('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.OK)
                 .end((err, res) => {
@@ -57,9 +57,9 @@ describe('좋아요 취소', () => {
     });
 
     describe('중복된 요청', () => {
-        it('DELETE /likes/{bookId} 요청 시 이미 처리된 요청임을 알림', (done) => {
+        it('DELETE /api/likes/{bookId} 요청 시 이미 처리된 요청임을 알림', (done) => {
             request(app)
-                .delete('/likes/1')
+                .delete('/api/likes/1')
                 .set("Authorization", `Bearer ${token}`)
                 .expect(StatusCodes.CONFLICT)
                 .end((err, res) => {

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+const assert = require('assert');
+const app = require('../app');
+const { StatusCodes } = require('http-status-codes');
+require('dotenv').config();
+
+const accessToken = process.env.TEST_TOKEN;
+const expiredToken = process.env.EXPIRED_TOKEN;
+const infiniteRefreshToken = process.env.INFINITE_REFRESH_TOKEN;
+
+describe('토큰 재발급', () => {
+    describe('정상 요청', () => {
+        it('GET /api/refresh 요청 시 accessToken 반환', (done) => {
+            request(app)
+                .get('/api/refresh')
+                .set("Authorization", `Bearer ${expiredToken}`)
+                .set("Cookie", `refreshToken=${infiniteRefreshToken}`)
+                .expect(StatusCodes.OK)
+                .end((err, res) => {
+                    if (err) return done(err);
+    
+                    res.body.hasOwnProperty('accessToken');
+    
+                    return done();
+                });
+        });
+    });
+
+    describe('만료되지 않은 access token 사용', () => {
+        it('GET /api/refresh 요청 시 만료되지 않았음을 알림', (done) => {
+            request(app)
+                .get('/api/refresh')
+                .set("Authorization", `Bearer ${accessToken}`)
+                .set("Cookie", `refreshToken=${infiniteRefreshToken}`)
+                .expect(StatusCodes.BAD_REQUEST)
+                .end((err, res) => {
+                    if (err) return done(err);
+    
+                    assert.strictEqual(res.body.message, 'Access token is not expired.');
+    
+                    return done();
+                });
+        });
+    });
+});

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -23,14 +23,7 @@ describe('회원가입', () => {
             request(app)
                 .post('/api/users/signup')
                 .send(fakeUserWrongPassword)
-                .expect(StatusCodes.BAD_REQUEST)
-                .end((err, res) => {
-                    if (err) return done(err);
-
-                    assert.strictEqual(res.body.message, "Request input validation fails.");
-
-                    return done();
-                });
+                .expect(StatusCodes.BAD_REQUEST, done);
         });
     });
 
@@ -115,14 +108,7 @@ describe('비밀번호 초기화(재설정)', () => {
             request(app)
                 .put('/api/users/reset-password')
                 .send(fakeUserWrongPassword)
-                .expect(StatusCodes.BAD_REQUEST)
-                .end((err, res) => {
-                    if (err) return done(err);
-
-                    assert.strictEqual(res.body.message, "Request input validation fails.");
-
-                    return done();
-                });
+                .expect(StatusCodes.BAD_REQUEST, done);
         });
     });
 


### PR DESCRIPTION
# Changes Made
- 모든 endpoint에 `/api` prefix 추가
- Access Token과 Refresh Token 도입
  - DB에 token table 생성
  - **로그인 API** 수정
    - 로그인 시 Access Token과 Refresh Token을 발급
    - Refresh Token은 DB token table에 (user_id, refresh_token) 형식으로 저장
    - Access Token은 response body에 Refresh Token은 cookie에 저장하여 반환
  - **로그아웃 API** 구현
    - 로그아웃 시 DB token table에 저장된 (user_id, refresh_token) 삭제
    - cookie의 "refreshToken" field도 clear
  - token 재발급을 위한 **token API** 추가 및 `/refresh` endpoint 구현
    - validation.middleware.js에 token 유효성 검증을 위한 코드 추가
    - header의 "Authorization" field를 확인(access token)하고 cookie의 "refreshToken" field를 확인(refresh token)
  - authorization.middleware.js에서 refresh token도 검증하도록 해서 access token은 유효하지만 refresh token이 만료되거나 DB에 없는 경우에 대해 재로그인 안내를 하도록 함
- token API test 코드 작성, request 시 refresh token cookie setting 코드 추가, README.md 테스트 결과 업데이트
# Next Steps
- Access Token과 Refresh Token이 도입되면서 test가 복잡해진터라 기존 test 코드에서 그에 맞게 조금씩 수정하다보니, 정상적으로 테스트가 실행되기는 하지만 코드가 정리가 안되어 있어서 수정이 필요할 것 같다.
- RTR(Refresh Token Rotation)을 써볼 수도 있을 것 같다.